### PR TITLE
Update spec to publish on DIF github org pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
   "author": "Stephen Curran",
   "license": "Apache 2.0",
   "bugs": {
-    "url": "https://github.com/bcgov/trustdidweb/issues"
+    "url": "https://github.com/decentralized-identity/trustdidweb/issues"
   },
-  "homepage": "https://github.com/bcgov/trustdidweb#readme",
+  "homepage": "https://github.com/decentralized-identity/trustdidweb#readme",
   "dependencies": {
     "spec-up": "github:brianorwhatever/spec-up#master"
   }

--- a/spec/header.md
+++ b/spec/header.md
@@ -6,7 +6,7 @@ Trust DID Web - `did:tdw`
 **Specification Version:** 0.3 (see [Changelog](#did-tdw-version-changelog))
 
 **Latest Draft:**
-  [https://github.com/bcgov/trustdidweb](https://github.com/bcgov/trustdidweb)
+  [https://github.com/decentralized-identity/trustdidweb](https://github.com/decentralized-identity/trustdidweb)
 
 **Editors:**
 ~ [Stephen Curran](https://github.com/swcurran)
@@ -17,9 +17,9 @@ Trust DID Web - `did:tdw`
 ~ [Martina Kolpondinos](https://github.com/martipos)
 
 **Participate:**
-~ [GitHub repo](https://github.com/bcgov/trustdidweb)
-~ [File a bug](https://github.com/bcgov/trustdidweb/issues)
-~ [Commit history](https://github.com/bcgov/trustdidweb/commits/main)
+~ [GitHub repo](https://github.com/decentralized-identity/trustdidweb)
+~ [File a bug](https://github.com/decentralized-identity/trustdidweb/issues)
+~ [Commit history](https://github.com/decentralized-identity/trustdidweb/commits/main)
 
 **Implementations:**
 ~ [TypeScript](https://github.com/bcgov/trustdidweb-ts)

--- a/specs.json
+++ b/specs.json
@@ -17,12 +17,12 @@
       ],
       "source": {
         "host": "github",
-        "account": "bcgov",
+        "account": "decentralized-identity",
         "repo": "trustdidweb"
       },
       "output_path": "./",
       "logo": "tdw.jpg",
-      "logo_link": "https://github.com/bcgov/trustdidweb",
+      "logo_link": "https://github.com/decentralized-identity/trustdidweb",
       "katex": true,
       "external_specs": [
         {


### PR DESCRIPTION
Updates the references in the SpecUp config and in the spec contents to be the DIF GitHub org instead of the BCGov org.