### PR TITLE
General updates to the agenda page and adding the Sept 12 meeting

### DIFF
--- a/agenda.md
+++ b/agenda.md
@@ -1,4 +1,4 @@
-# Trust DID Web Work Item Rolling Agenda
+# Trust DID Web Work Item Rolling Agenda<!-- omit in toc -->
 
 Zoom Link: https://us02web.zoom.us/j/83119969275?pwd=IZTuXgGLtdLPjPLuB6q8zHXazxHSsU.1
 
@@ -6,10 +6,11 @@ Zoom Link: https://us02web.zoom.us/j/83119969275?pwd=IZTuXgGLtdLPjPLuB6q8zHXazxH
 
 [**WG projects** ](https://github.com/decentralized-identity?q=wg-cc&type=&language=) | [ DIF page ](https://identity.foundation/working-groups/claims-credentials.html) | [Mailing list and Wiki ](https://lists.identity.foundation/g/cc-wg) | [Meeting recordings](https://docs.google.com/spreadsheets/d/1wgccmMvIImx30qVE9GhRKWWv3vmL2ZyUauuKx3IfRmA/edit?gid=111226877#gid=111226877)
 
+## Table of Contents<!-- omit in toc -->
 
-## Table of Contents
-
-> [TOC]
+- [Meeting Information](#meeting-information)
+- [Future Topics:](#future-topics)
+- [Meeting - 12 Sept 2024](#meeting---12-sept-2024)
 
 ## Meeting Information
 
@@ -22,7 +23,6 @@ Zoom Link: https://us02web.zoom.us/j/83119969275?pwd=IZTuXgGLtdLPjPLuB6q8zHXazxH
 _Participants are encouraged to turn your video on. This is a good way to build rapport across the contributor community._
 
 _This document is live-edited DURING each call, and stable/authoritative copies live on our github repo under `/agenda.md`, link: [Agenda]._
-
 
 [join DIF]: https://identity.foundation/join
 [sign the WG charter]: https://bit.ly/DIF-WG-select1
@@ -52,10 +52,11 @@ Attendees:
     2. Please make sure you: [join DIF], [sign the WG Charter], and follow the [DIF Code of Conduct]. Questions? Please contact [operations@identity.foundation]. 
     3. [did:tdw Specification license] -- W3C Mode
     4. Introductions and Agenda Topics
-3. Brief(!) Introduction to `did:tdw`
-4. Introduction to the `did:tdw` Work Item at DIF
-5. Discussion:
+2. Brief(!) Introduction to `did:tdw`
+3. Introduction to the `did:tdw` Work Item at DIF
+4. Discussion:
     1. What do you want this group to achieve?
     2. What would help you the most?
-6. Future Topics
+5. Future Topics
+6. [Spec. PRs and Issues](https://github.com/decentralized-identity/trustdidweb)
 7. Action items and next steps

--- a/agenda.md
+++ b/agenda.md
@@ -1,41 +1,61 @@
-# trustdidweb - rolling agenda & minutes
+# Trust DID Web Work Item Rolling Agenda
+
+Zoom Link: https://us02web.zoom.us/j/83119969275?pwd=IZTuXgGLtdLPjPLuB6q8zHXazxHSsU.1
 
 [![hackmd-github-sync-badge](https://hackmd.io/3aEr9Zp_T8GziXQEpah4Gg/badge)](https://hackmd.io/3aEr9Zp_T8GziXQEpah4Gg)
 
+[**WG projects** ](https://github.com/decentralized-identity?q=wg-cc&type=&language=) | [ DIF page ](https://identity.foundation/working-groups/claims-credentials.html) | [Mailing list and Wiki ](https://lists.identity.foundation/g/cc-wg) | [Meeting recordings](https://docs.google.com/spreadsheets/d/1wgccmMvIImx30qVE9GhRKWWv3vmL2ZyUauuKx3IfRmA/edit?gid=111226877#gid=111226877)
 
-[**WG projects** ](https://github.com/decentralized-identity?q=wg-id&type=&language=) | [ DIF page ](https://identity.foundation/working-groups/identifiers-discovery.html) | [Mailing list and Wiki ](https://lists.identity.foundation/g/cc-id) | [Meeting recordings](https://docs.google.com/spreadsheets/d/1wgccmMvIImx30qVE9GhRKWWv3vmL2ZyUauuKx3IfRmA/edit?gid=111226877#gid=111226877)
 
-_For this call, you are encouraged to turn your video on. This is a good way to build rapport given we are a large, disparate group experiencing a lot of churn._
+## Table of Contents
 
-_This document is live-edited DURING each call, and stable/authoritative copies live on our github repo under /agenda.md .
-Please note that we might not notice a pullrequest in time, but you are free to propose agenda items for future meetings via hackmd._
+> [TOC]
 
-<details>
-<summary> Meeting information </summary>
+## Meeting Information
 
-- Before you contribute
-	- [**Join DIF**](https://identity.foundation/join) and [sign the WG charter](https://bit.ly/DIF-WG-select1) (both are required!)
-	- [**Refer to DIF's code of conduct**](https://github.com/decentralized-identity/org/blob/master/code-of-conduct.md)
-- Time: 9am PT, Thursdays bi-weekly
-- [Calendar entry](https://calendar.google.com/event?action=TEMPLATE&tmeid=NG5jYWowbmZsdWNzM21tYjBsbDIzdG50ZzFfMjAyNDA5MTJUMTYwMDAwWiBkZWNlbnRyYWxpemVkLmlkZW50aXR5QG0&tmsrc=decentralized.identity%40gmail.com&scp=ALL)
-- [Zoom room](https://us02web.zoom.us/j/83119969275?pwd=IZTuXgGLtdLPjPLuB6q8zHXazxHSsU.1)
-</details>
+- Before you contribute - **[join DIF]** and [sign the WG charter] (both are required!)
+- Meeting Time: Every second Thursday at 9:00 Pacific / 18:00 Central Europe
+- [Calendar entry]
+- [ID WG participation tracking]
+- [Zoom room]
 
-#### Future topics:
+_Participants are encouraged to turn your video on. This is a good way to build rapport across the contributor community._
 
-<details>
-<summary> Topics for upcoming meetings</summary>
+_This document is live-edited DURING each call, and stable/authoritative copies live on our github repo under `/agenda.md`, link: [Agenda]._
 
-- topic 1 (to be discussed on this date)
-- topic 2 (to be discussed on this date)
-- topic n. (tbd)
 
-</details>
+[join DIF]: https://identity.foundation/join
+[sign the WG charter]: https://bit.ly/DIF-WG-select1
+[Calendar entry]: https://calendar.google.com/event?action=TEMPLATE&tmeid=NG5jYWowbmZsdWNzM21tYjBsbDIzdG50ZzFfMjAyNDA5MTJUMTYwMDAwWiBkZWNlbnRyYWxpemVkLmlkZW50aXR5QG0&tmsrc=decentralized.identity%40gmail.com&scp=ALL
+[Zoom Room]: https://us02web.zoom.us/j/83119969275?pwd=IZTuXgGLtdLPjPLuB6q8zHXazxHSsU.1
+[DIF Code of Conduct]: https://github.com/decentralized-identity/org/blob/master/code-of-conduct.md
+[ID WG participation tracking]: https://docs.google.com/spreadsheets/d/12hFa574v5PRrKfzIKMgDTjxuU6lvtBhrmLspfKkN4oE/edit#gid=0
+[operations@identity.foundation]: mailto:operations@identity.foundation
+[did:tdw Specification license]: https://github.com/decentralized-identity/trustdidweb/blob/main/LICENSE.md
+[Agenda]: https://github.com/decentralized-identity/trustdidweb/blob/main/agenda.md
 
-## Meeting - 12 Sept 2024 - (1200 ET)
+## Future Topics:
 
-1. Welcome and introductions
-2. [WG participation tracking](https://docs.google.com/spreadsheets/d/12hFa574v5PRrKfzIKMgDTjxuU6lvtBhrmLspfKkN4oE/edit#gid=0)
-3. Review of issues and pull requests
-4. Main topics
-5. Action item and next steps
+- Using the `did:tdw` log format with other DID Methods
+- Merge `did:tdw` features into `did:web`?
+- Implementor's experiences -- architectures, learnings
+- Trust DID Web Server -- implementations and specification
+
+## Meeting - 12 Sept 2024
+
+Time: 9:00 Pacific / 18:00 Central Europe
+
+Attendees: 
+
+1. Welcome and Procedural Considerations
+    1. Recording on?
+    2. Please make sure you: [join DIF], [sign the WG Charter], and follow the [DIF Code of Conduct]. Questions? Please contact [operations@identity.foundation]. 
+    3. [did:tdw Specification license] -- W3C Mode
+    4. Introductions and Agenda Topics
+3. Brief(!) Introduction to `did:tdw`
+4. Introduction to the `did:tdw` Work Item at DIF
+5. Discussion:
+    1. What do you want this group to achieve?
+    2. What would help you the most?
+6. Future Topics
+7. Action items and next steps


### PR DESCRIPTION
Updates the agenda page in a general way, and adds the agenda for the meeting on Sept 12.

The changes tunes the template to make more sense for Trust DID Web and for me in hosting.
