### PR TITLE
Update agenda following 2024-09-26 meeting

### DIFF
--- a/agenda.md
+++ b/agenda.md
@@ -10,6 +10,8 @@ Agenda: [HackMD](https://hackmd.io/k4cIK9vQSlaeg2pdHE51IQ), [TrustDIDWeb Reposit
 
 - [Meeting Information](#meeting-information)
 - [Future Topics](#future-topics)
+- [Meeting - 10 Oct 2024](#meeting---10-oct-2024)
+- [Meeting - 26 Sept 2024](#meeting---26-sept-2024)
 - [Meeting - 12 Sept 2024](#meeting---12-sept-2024)
 
 ## Meeting Information
@@ -47,11 +49,68 @@ _This document is live-edited DURING each call, and stable/authoritative copies 
 - Trust DID Web Server -- implementations, [such as this one](https://github.com/decentralized-identity/trustdidweb-server-py), specification
 - A did:tdw test suite -- such as proposed [here](https://github.com/nuts-foundation/trustdidweb-go/pull/1)
 
-## Meeting - 12 Sept 2024
+====================================================================
+## Meeting - 10 Oct 2024
 
 Time: 9:00 Pacific / 18:00 Central Europe
 
-Meeting Recording: [Zoom Recording](https://us02web.zoom.us/rec/share/-tz_UHUxqNxkGntAcYZEaYD1_EDX4RBVmtwd7JbGKFglgwTYzJUzkC2ZuFRFZftt.-wWj9ZMqS70V8Cwg)
+Attendees:
+
+- Stephen Curran
+- 
+
+1. Welcome and Adminstrivia
+    1. Recording on?
+    2. Please make sure you: [join DIF], [sign the WG Charter], and follow the [DIF Code of Conduct]. Questions? Please contact [operations@identity.foundation].
+    3. [did:tdw Specification license] -- W3C Mode
+    4. Introductions and Agenda Topics
+2. To Be Determined
+3. Update on the [did:tdw Web Server](https://github.com/decentralized-identity/trustdidweb-server-py) -- Patrick St. Louis.
+    8. Demo given, but we ran out of time.
+4. [DID Linked Resources](https://w3c-ccg.github.io/DID-Linked-Resources/) and did:tdw
+    1. Should we? How?
+5. [Spec. PRs and Issues](https://github.com/decentralized-identity/trustdidweb)
+6. Open Discussion
+
+## Meeting - 26 Sept 2024
+
+Time: 9:00 Pacific / 18:00 Central Europe
+
+Attendees:
+
+- Stephen Curran
+- Others...
+
+1. Welcome and Adminstrivia
+    1. Recording on?
+    2. Please make sure you: [join DIF], [sign the WG Charter], and follow the [DIF Code of Conduct]. Questions? Please contact [operations@identity.foundation].
+    3. [did:tdw Specification license] -- W3C Mode
+    4. Introductions and Agenda Topics
+2. Feedback from implementing `did:tdw` Witness capability -- Brian Richter.
+    1. Resolver has a /witness endpoint -- got the request from the DID Controller.
+    2. Stuck on signing the entry. Both log entries have a did:key -- the witnesses must be published DIDs -- **SHOULD** be a did:tdw?
+    3. Where to send the witness request? The DID Controller should know that. 
+    4. Perhaps add an endpoint for the witnesses in the `witnesses` object? Decided no -- not to include the endpoint since that puts too much definition in the specification on how to implement the DID Controller and Witness interface. It is left to the DID Controller and witnesses to decide how they will interact. All that is specified is that  resolvers can verify the proofs via the DID referenced in the `witnesses` object, and the key identifier that references that DID in the proof itself.
+    5. Use cases for witnesses -- (1) monitoring the DID controller to prevent maliciousness -- no backtracking, (2) preventing attacks on the DID Controller.
+    6. Next steps -- Brian to continue implementing based on the discussion. Addition of weasel words to the spec to note the implementation challenges.
+4. Spec. update to switch from a DID log entry being a JSON array to an object.  Feedback? -- Stephen Curran. Good to go with the names of the items in the object.
+    1. General feedback -- all good.
+    2. We reviewed the names and agreed with the ones in the PR now -- `versionId`, `versionTime` (both of which align with the DID Core spec query parameters), `parameters`, and `state`. `proof` is as defined in the DI specification.
+6. Proof Chain vs. Proof Set
+    1. Semantics:
+        1. Proof Chain implies that that a subsequent signature is added to an existing signature, implying an attestation of that signature. But there are no implementations of it that we know of, and it's inclusion adds complexity without the semantics giving much benefit in `did:tdw`.
+        2. Proof sets are just independent proofs across the same data.
+    3. For now, let's just go with proof sets, as there is little benefit from using proof chains.
+7. Update on the [did:tdw Web Server](https://github.com/decentralized-identity/trustdidweb-server-py) -- Patrick St. Louis.
+    8. Demo given, but we ran out of time.
+9. [DID Linked Resources](https://w3c-ccg.github.io/DID-Linked-Resources/) and did:tdw
+    1. Should we?
+10. [Spec. PRs and Issues](https://github.com/decentralized-identity/trustdidweb)
+11. Open Discussion
+
+## Meeting - 12 Sept 2024
+
+Time: 9:00 Pacific / 18:00 Central Europe
 
 Attendees:
 
@@ -64,6 +123,7 @@ Attendees:
 * Martina Kolpondinos
 * John Jordan
 * Patrick St. Louis
+* Jamie Hale
 
 1. Welcome and Adminstrivia
     1. Recording on?

--- a/agenda.md
+++ b/agenda.md
@@ -54,6 +54,8 @@ _This document is live-edited DURING each call, and stable/authoritative copies 
 
 Time: 9:00 Pacific / 18:00 Central Europe
 
+Recording: To Be Added
+
 Attendees:
 
 - Stephen Curran
@@ -75,6 +77,8 @@ Attendees:
 ## Meeting - 26 Sept 2024
 
 Time: 9:00 Pacific / 18:00 Central Europe
+
+Recording: [Zoom Recording Link](https://us02web.zoom.us/rec/share/VQ1FPX8yumZWnt7WVUYzvPgxcWA2WZZajGDbdDurqfc4T9V4VEEYrbmRiQoHcHc.DBkCFEu9ObvfsWg0)
 
 Attendees:
 
@@ -111,6 +115,8 @@ Attendees:
 ## Meeting - 12 Sept 2024
 
 Time: 9:00 Pacific / 18:00 Central Europe
+
+Recording: [Zoom Recording Link](https://us02web.zoom.us/rec/share/-tz_UHUxqNxkGntAcYZEaYD1_EDX4RBVmtwd7JbGKFglgwTYzJUzkC2ZuFRFZftt.-wWj9ZMqS70V8Cwg)
 
 Attendees:
 


### PR DESCRIPTION
Updates the meeting notes from the Sept. 26 meeting and adds the tentative agenda for the Oct. 10 meeting.

Signed-off-by: Stephen Curran <swcurran@gmail.com>
