### PR TITLE
Fix header link to the changelog

### DIFF
--- a/spec/header.md
+++ b/spec/header.md
@@ -3,7 +3,7 @@ Trust DID Web - `did:tdw`
 
 **Specification Status:** DRAFT
 
-**Specification Version:** 0.4 (see [Changelog](#did-tdw-version-changelog))
+**Specification Version:** 0.4 (see [Changelog](#didtdw-version-changelog))
 
 **Latest Draft:**
   [https://github.com/decentralized-identity/trustdidweb](https://github.com/decentralized-identity/trustdidweb)


### PR DESCRIPTION
The current link to the changelog in the header does not work because it does not match the changelog chapter id.

the link contains: https://identity.foundation/trustdidweb/#did-tdw-version-changelog

But it should contain: https://identity.foundation/trustdidweb/#didtdw-version-changelog