### PR TITLE
Add spec-up external spec

### DIFF
--- a/spec/definitions.md
+++ b/spec/definitions.md
@@ -121,7 +121,7 @@ Specification](https://identity.foundation/linked-vp/).
 
 [[def: multihash]]
 
-~ Per the [[spec:draft-multiformats-multihash-07]], [[ref: multihash]] is a specification
+~ Per the [[spec:multiformats]], [[ref: multihash]] is a specification
 for differentiating instances of hashes. Software creating a hash prefixes
 (according to the specification) data to the hash indicating the algorithm used
 and the length of the hash, so that software receiving the hash knows how to

--- a/specs.json
+++ b/specs.json
@@ -24,8 +24,22 @@
       "katex": true,
       "external_specs": [
         {
-          "LINKED-VP": "https://identity.foundation/linked-vp/",
+          "LINKED-VP": "https://identity.foundation/linked-vp/"
+        },
+        {
           "TOIP": "https://trustoverip.github.io/ctwg-main-glossary/"
+        },
+        {
+          "multiformats": {
+            "href": "https://datatracker.ietf.org/doc/draft-multiformats-multibase/08/",
+            "title": "Multiformats",
+            "rawDate": "2024-02-21",
+            "authors": [
+              "Juan Benet",
+              "Manu Sporny"
+            ],
+            "status": "Internet Draft"
+          }
         }
       ]
     }


### PR DESCRIPTION
I've set it up to use the same `external_specs` property that external refs use. It checks whether the spec maps to a string or object and does the external reference functionality for strings and this functionality for objects... probably not ideal and they can likely be the same thing I just didn't want to break the API for anyone currently using `external_specs`... You can take a look at the spec-up change that is required [here](https://github.com/brianorwhatever/spec-up/commit/fcab95edb4cc8d2a70f8c053e227220dbd6a08de)